### PR TITLE
Change return type of min() and max()

### DIFF
--- a/hdr_histogram_wrap.cc
+++ b/hdr_histogram_wrap.cc
@@ -91,13 +91,13 @@ NAN_METHOD(HdrHistogramWrap::Record) {
 NAN_METHOD(HdrHistogramWrap::Min) {
   HdrHistogramWrap* obj = Nan::ObjectWrap::Unwrap<HdrHistogramWrap>(info.This());
   int64_t value = hdr_min(obj->histogram);
-  info.GetReturnValue().Set((int32_t) value);
+  info.GetReturnValue().Set((double) value);
 }
 
 NAN_METHOD(HdrHistogramWrap::Max) {
   HdrHistogramWrap* obj = Nan::ObjectWrap::Unwrap<HdrHistogramWrap>(info.This());
   int64_t value = hdr_max(obj->histogram);
-  info.GetReturnValue().Set((int32_t) value);
+  info.GetReturnValue().Set((double) value);
 }
 
 NAN_METHOD(HdrHistogramWrap::Mean) {

--- a/test.js
+++ b/test.js
@@ -116,3 +116,23 @@ test('percentiles', (t) => {
   }], 'percentiles matches')
   t.end()
 })
+
+test('support >2e9', (t) => {
+  const recordValue = 4 * 1e9; 
+  const instance = Histogram(1, recordValue);
+  var compare = (a, b) => {
+    var diff = Math.abs(a - b);
+    // hdr_min and hdr_max do not return precise data, even before
+    // conversion to double.
+    if (diff < 1e-3 * Math.min(Math.abs(a), Math.abs(b)))
+      return true;
+    else {
+      console.error(`Mismatch! Got ${a}, expected ${b}!`);
+      return false;
+    }
+  }
+  t.ok(instance.record(recordValue));
+  t.ok(compare(instance.min(), recordValue), 'min match')
+  t.ok(compare(instance.max(), recordValue), 'max match')
+  t.end();
+});

--- a/test.js
+++ b/test.js
@@ -118,21 +118,21 @@ test('percentiles', (t) => {
 })
 
 test('support >2e9', (t) => {
-  const recordValue = 4 * 1e9; 
-  const instance = Histogram(1, recordValue);
+  const recordValue = 4 * 1e9
+  const instance = Histogram(1, recordValue)
   var compare = (a, b) => {
-    var diff = Math.abs(a - b);
+    var diff = Math.abs(a - b)
     // hdr_min and hdr_max do not return precise data, even before
     // conversion to double.
-    if (diff < 1e-3 * Math.min(Math.abs(a), Math.abs(b)))
-      return true;
-    else {
-      console.error(`Mismatch! Got ${a}, expected ${b}!`);
-      return false;
+    if (diff < 1e-3 * Math.min(Math.abs(a), Math.abs(b))) {
+      return true
+    } else {
+      console.error(`Mismatch! Got ${a}, expected ${b}!`)
+      return false
     }
   }
-  t.ok(instance.record(recordValue));
+  t.ok(instance.record(recordValue))
   t.ok(compare(instance.min(), recordValue), 'min match')
   t.ok(compare(instance.max(), recordValue), 'max match')
-  t.end();
+  t.end()
 });

--- a/test.js
+++ b/test.js
@@ -135,4 +135,4 @@ test('support >2e9', (t) => {
   t.ok(compare(instance.min(), recordValue), 'min match')
   t.ok(compare(instance.max(), recordValue), 'max match')
   t.end()
-});
+})


### PR DESCRIPTION
This will make `min()` and `max()` return `double` instead of `int32_t` preventing 32bit overflow.

A test is added for values greater than 2e9. As it turns out `min()` (and `max()`) internally uses `hdr_min` (and `hdr_max`) which does not return precise value,  even before conversion from `int64_t`  to `double`. Thus allowed relative error in the test is big.

Fixes: https://github.com/mcollina/autocannon/issues/87
