### PR TITLE
deps: update dependencies to make it work with Node.js 10

### DIFF
--- a/hdr_histogram_wrap.cc
+++ b/hdr_histogram_wrap.cc
@@ -71,7 +71,8 @@ NAN_METHOD(HdrHistogramWrap::New) {
       info[2]
     };
     v8::Local<v8::Function> cons = Nan::New(constructor);
-    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+    v8::MaybeLocal<v8::Object> wrap = cons->NewInstance(Nan::GetCurrentContext(), argc, argv);
+    info.GetReturnValue().Set(wrap.ToLocalChecked());
   }
 }
 
@@ -152,12 +153,12 @@ NAN_METHOD(HdrHistogramWrap::Decode) {
   size_t len  = node::Buffer::Length(buf);
   const int argc = 0;
   v8::Local<v8::Function> cons = Nan::New(constructor);
-  v8::Local<v8::Object> wrap = cons->NewInstance(argc, NULL);
-  HdrHistogramWrap* obj = Nan::ObjectWrap::Unwrap<HdrHistogramWrap>(wrap);
+  v8::MaybeLocal<v8::Object> wrap = cons->NewInstance(Nan::GetCurrentContext(), argc, nullptr);
+  HdrHistogramWrap* obj = Nan::ObjectWrap::Unwrap<HdrHistogramWrap>(wrap.ToLocalChecked());
 
   hdr_log_decode(&obj->histogram, encoded, len);
 
-  info.GetReturnValue().Set(wrap);
+  info.GetReturnValue().Set(wrap.ToLocalChecked());
 }
 
 NAN_METHOD(HdrHistogramWrap::Percentiles) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,16 +2,17 @@
   "name": "native-hdr-histogram",
   "version": "0.4.6",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -19,6 +20,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -31,7 +35,11 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -57,26 +65,36 @@
       "dev": true
     },
     "aproba": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
+      }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -113,10 +131,30 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.61.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.61.0.tgz",
-      "integrity": "sha1-LBBHiOFpbnBgxv+qHGVg1vnIhK8=",
-      "dev": true
+      "version": "2.228.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.228.1.tgz",
+      "integrity": "sha1-V7PMKWccvICjbUW76tqK0mkHny0=",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17",
+        "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -124,32 +162,38 @@
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "bl": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -161,7 +205,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -174,35 +224,59 @@
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "buffer": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
-      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -219,12 +293,19 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clean-yaml-object": {
@@ -237,18 +318,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "co": {
@@ -266,6 +350,10 @@
       "resolved": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.1.6.tgz",
       "integrity": "sha1-Wd/QLaH/McL7K5Uq2K0W/TeBtyg=",
       "dev": true,
+      "requires": {
+        "request": "2.42.0",
+        "urlgrey": "0.4.0"
+      },
       "dependencies": {
         "asn1": {
           "version": "0.1.11",
@@ -292,7 +380,10 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "0.9.1"
+          }
         },
         "caseless": {
           "version": "0.6.0",
@@ -305,14 +396,20 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
         },
         "cryptiles": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
           "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "0.4.2"
+          }
         },
         "delayed-stream": {
           "version": "0.0.5",
@@ -332,14 +429,25 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "async": "0.9.2",
+            "combined-stream": "0.0.7",
+            "mime": "1.2.11"
+          }
         },
         "hawk": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
           "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "0.4.2",
+            "cryptiles": "0.2.2",
+            "hoek": "0.9.1",
+            "sntp": "0.2.4"
+          }
         },
         "hoek": {
           "version": "0.9.1",
@@ -352,7 +460,12 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
         },
         "mime-types": {
           "version": "1.0.2",
@@ -383,14 +496,34 @@
           "version": "2.42.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.5.0",
+            "bl": "0.9.5",
+            "caseless": "0.6.0",
+            "forever-agent": "0.5.2",
+            "form-data": "0.1.4",
+            "hawk": "1.1.1",
+            "http-signature": "0.10.1",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "1.0.2",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.4.0",
+            "qs": "1.2.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3"
+          }
         },
         "sntp": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
           "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "0.9.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",
@@ -401,20 +534,23 @@
       }
     },
     "color-support": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz",
-      "integrity": "sha1-ScyZuJ0b3vEpLp2TI8ZpcaM+uJ0=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "concat-map": {
@@ -423,10 +559,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -439,10 +581,17 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
       "dependencies": {
         "caseless": {
           "version": "0.11.0",
@@ -460,13 +609,23 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.15.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "js-yaml": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
+          }
         },
         "minimist": {
           "version": "1.2.0",
@@ -484,7 +643,29 @@
           "version": "2.79.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.2.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",
@@ -498,18 +679,20 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.2.14"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
-    },
-    "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
-      "dev": true
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "ctype": {
       "version": "0.5.3",
@@ -522,12 +705,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.42"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -537,9 +726,12 @@
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "debug-log": {
       "version": "1.0.1",
@@ -574,7 +766,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.4"
+      }
     },
     "defined": {
       "version": "0.0.0",
@@ -587,11 +782,20 @@
       "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.1.2.tgz",
       "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
       "dev": true,
+      "requires": {
+        "find-root": "1.1.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.8",
+        "uniq": "1.0.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "ignore": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-          "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+          "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
           "dev": true
         }
       }
@@ -600,7 +804,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -612,6 +825,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -622,7 +840,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -634,43 +856,81 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "es5-ext": {
-      "version": "0.10.22",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.22.tgz",
-      "integrity": "sha512-YXTXSlZkJsVwMEVljp1Bh5P9+Raa3524OMl9kywGMp1aazKTCnAqORRL/8dkuqNHk+LRYe0LezuS8PlUt3+mOw==",
-      "dev": true
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
+      }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -682,19 +942,67 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.2.0.tgz",
       "integrity": "sha1-bI10OpFUZZW6GG7e0JZoL0dZjeg=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.4",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.2",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "6.0.4",
+        "globals": "8.18.0",
+        "ignore": "2.2.19",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.11.0",
+        "json-stable-stringify": "1.0.1",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "resolve": "1.7.1",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "strip-json-comments": {
           "version": "1.0.4",
@@ -735,29 +1043,28 @@
       "dev": true
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
+      "requires": {
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -767,9 +1074,9 @@
       "dev": true
     },
     "estraverse-fb": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
-      "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
       "dev": true
     },
     "esutils": {
@@ -782,6 +1089,16 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "events-to-array": {
@@ -802,9 +1119,9 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -816,37 +1133,59 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
     },
     "find-root": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
+      "requires": {
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
+      },
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.2",
+            "which": "1.2.14"
+          }
         }
       }
     },
@@ -858,7 +1197,12 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -868,17 +1212,38 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
     },
     "fstream-ignore": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
     },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -890,7 +1255,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-stdin": {
       "version": "5.0.1",
@@ -902,6 +1270,9 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -913,7 +1284,15 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "8.18.0",
@@ -925,18 +1304,20 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
     },
     "har-schema": {
       "version": "1.0.5",
@@ -946,13 +1327,20 @@
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -962,7 +1350,13 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -972,7 +1366,12 @@
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
     },
     "ieee754": {
       "version": "1.1.8",
@@ -989,7 +1388,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -997,26 +1400,57 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.10",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1025,16 +1459,22 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -1043,9 +1483,9 @@
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-typedarray": {
@@ -1075,17 +1515,15 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
     },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
-    },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1101,7 +1539,10 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1120,9 +1561,15 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1141,12 +1588,16 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "log-driver": {
@@ -1156,10 +1607,14 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-      "dev": true
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "mime": {
       "version": "1.2.11",
@@ -1169,19 +1624,25 @@
       "optional": true
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -1191,7 +1652,10 @@
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -1202,7 +1666,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
       "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "strip-indent": "1.0.1"
+      }
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -1211,24 +1678,53 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "node-pre-gyp": {
-      "version": "0.6.36",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-      "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y="
+      "version": "0.6.39",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+      "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "hawk": "3.1.3",
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.6",
+        "request": "2.81.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.1"
+      }
     },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00="
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
+      }
     },
     "npmlog": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1240,11 +1736,37 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-6.6.1.tgz",
       "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
       "dev": true,
+      "requires": {
+        "append-transform": "0.4.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.2.0",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.1",
+        "glob": "7.0.3",
+        "istanbul": "0.4.3",
+        "md5-hex": "1.3.0",
+        "micromatch": "2.3.8",
+        "mkdirp": "0.5.1",
+        "pkg-up": "1.0.0",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.2",
+        "signal-exit": "3.0.0",
+        "source-map": "0.5.6",
+        "spawn-wrap": "1.2.3",
+        "test-exclude": "1.1.0",
+        "yargs": "4.7.1"
+      },
       "dependencies": {
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
         },
         "arrify": {
           "version": "1.0.1",
@@ -1255,11 +1777,21 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.1.4"
+          },
           "dependencies": {
             "write-file-atomic": {
               "version": "1.1.4",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.4",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              },
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
@@ -1289,11 +1821,17 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          },
           "dependencies": {
             "strip-bom": {
               "version": "2.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              },
               "dependencies": {
                 "is-utf8": {
                   "version": "0.2.1",
@@ -1308,6 +1846,11 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          },
           "dependencies": {
             "commondir": {
               "version": "1.0.1",
@@ -1317,7 +1860,10 @@
             "pkg-dir": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2"
+              }
             }
           }
         },
@@ -1325,16 +1871,26 @@
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          },
           "dependencies": {
             "path-exists": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
             },
             "pinkie-promise": {
               "version": "2.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              },
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
@@ -1349,16 +1905,29 @@
           "version": "1.5.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "cross-spawn-async": "2.2.4",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
+          },
           "dependencies": {
             "cross-spawn-async": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "lru-cache": "4.0.1",
+                "which": "1.2.10"
+              },
               "dependencies": {
                 "lru-cache": {
                   "version": "4.0.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.0.0"
+                  },
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
@@ -1383,6 +1952,9 @@
               "version": "1.2.10",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
@@ -1397,11 +1969,22 @@
           "version": "7.0.3",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          },
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -1419,11 +2002,18 @@
               "version": "3.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.4"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.4",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.1",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.1",
@@ -1443,6 +2033,9 @@
               "version": "1.3.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -1462,6 +2055,22 @@
           "version": "0.4.3",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "abbrev": "1.0.7",
+            "async": "1.5.2",
+            "escodegen": "1.8.0",
+            "esprima": "2.7.2",
+            "fileset": "0.2.1",
+            "handlebars": "4.0.5",
+            "js-yaml": "3.6.1",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.3.3",
+            "resolve": "1.1.7",
+            "supports-color": "3.1.2",
+            "which": "1.2.10",
+            "wordwrap": "1.0.0"
+          },
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
@@ -1477,6 +2086,13 @@
               "version": "1.8.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "esprima": "2.7.2",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.1",
+                "source-map": "0.2.0"
+              },
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
@@ -1492,6 +2108,14 @@
                   "version": "0.8.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "deep-is": "0.1.3",
+                    "fast-levenshtein": "1.1.3",
+                    "levn": "0.3.0",
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2",
+                    "wordwrap": "1.0.0"
+                  },
                   "dependencies": {
                     "deep-is": {
                       "version": "0.1.3",
@@ -1506,7 +2130,11 @@
                     "levn": {
                       "version": "0.3.0",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
+                      }
                     },
                     "prelude-ls": {
                       "version": "1.1.2",
@@ -1516,7 +2144,10 @@
                     "type-check": {
                       "version": "0.3.2",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "prelude-ls": "1.1.2"
+                      }
                     }
                   }
                 },
@@ -1525,6 +2156,9 @@
                   "bundled": true,
                   "dev": true,
                   "optional": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
@@ -1545,16 +2179,31 @@
               "version": "0.2.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "glob": "5.0.15",
+                "minimatch": "2.0.10"
+              },
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.5",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -1579,11 +2228,18 @@
                   "version": "2.0.10",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.4"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.4",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.1",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.1",
@@ -1605,11 +2261,21 @@
               "version": "4.0.5",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.6.2"
+              },
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
@@ -1627,6 +2293,9 @@
                   "version": "0.4.4",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
@@ -1640,6 +2309,12 @@
                   "bundled": true,
                   "dev": true,
                   "optional": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "source-map": "0.5.6",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.10.0"
+                  },
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
@@ -1664,6 +2339,12 @@
                       "bundled": true,
                       "dev": true,
                       "optional": true,
+                      "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                      },
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
@@ -1676,24 +2357,41 @@
                           "bundled": true,
                           "dev": true,
                           "optional": true,
+                          "requires": {
+                            "center-align": "0.1.3",
+                            "right-align": "0.1.3",
+                            "wordwrap": "0.0.2"
+                          },
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
                               "bundled": true,
                               "dev": true,
                               "optional": true,
+                              "requires": {
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
+                              },
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
                                   "bundled": true,
                                   "dev": true,
                                   "optional": true,
+                                  "requires": {
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
+                                  },
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
                                       "bundled": true,
                                       "dev": true,
                                       "optional": true,
+                                      "requires": {
+                                        "is-buffer": "1.1.3"
+                                      },
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
@@ -1730,18 +2428,29 @@
                               "bundled": true,
                               "dev": true,
                               "optional": true,
+                              "requires": {
+                                "align-text": "0.1.4"
+                              },
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
                                   "bundled": true,
                                   "dev": true,
                                   "optional": true,
+                                  "requires": {
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
+                                  },
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
                                       "bundled": true,
                                       "dev": true,
                                       "optional": true,
+                                      "requires": {
+                                        "is-buffer": "1.1.3"
+                                      },
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
@@ -1797,11 +2506,18 @@
               "version": "3.6.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "argparse": "1.0.7",
+                "esprima": "2.7.2"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "1.0.7",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -1815,12 +2531,18 @@
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "abbrev": "1.0.7"
+              }
             },
             "once": {
               "version": "1.3.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -1838,6 +2560,9 @@
               "version": "3.1.2",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              },
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
@@ -1850,6 +2575,9 @@
               "version": "1.2.10",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
@@ -1869,6 +2597,9 @@
           "version": "1.3.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          },
           "dependencies": {
             "md5-o-matic": {
               "version": "0.1.1",
@@ -1881,11 +2612,29 @@
           "version": "2.3.8",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.3",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          },
           "dependencies": {
             "arr-diff": {
               "version": "2.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "arr-flatten": "1.0.1"
+              },
               "dependencies": {
                 "arr-flatten": {
                   "version": "1.0.1",
@@ -1903,26 +2652,47 @@
               "version": "1.8.5",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              },
               "dependencies": {
                 "expand-range": {
                   "version": "1.8.2",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "fill-range": "2.2.3"
+                  },
                   "dependencies": {
                     "fill-range": {
                       "version": "2.2.3",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.5",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.5.4"
+                      },
                       "dependencies": {
                         "is-number": {
                           "version": "2.1.0",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "kind-of": "3.0.3"
+                          }
                         },
                         "isobject": {
                           "version": "2.1.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "isarray": "1.0.0"
+                          },
                           "dependencies": {
                             "isarray": {
                               "version": "1.0.0",
@@ -1934,7 +2704,11 @@
                         "randomatic": {
                           "version": "1.1.5",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "is-number": "2.1.0",
+                            "kind-of": "3.0.3"
+                          }
                         },
                         "repeat-string": {
                           "version": "1.5.4",
@@ -1961,6 +2735,9 @@
               "version": "0.1.5",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              },
               "dependencies": {
                 "is-posix-bracket": {
                   "version": "0.1.1",
@@ -1972,7 +2749,10 @@
             "extglob": {
               "version": "0.3.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
             },
             "filename-regex": {
               "version": "2.0.0",
@@ -1987,12 +2767,18 @@
             "is-glob": {
               "version": "2.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
             },
             "kind-of": {
               "version": "3.0.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-buffer": "1.1.3"
+              },
               "dependencies": {
                 "is-buffer": {
                   "version": "1.1.3",
@@ -2010,11 +2796,18 @@
               "version": "2.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "for-own": "0.1.4",
+                "is-extendable": "0.1.1"
+              },
               "dependencies": {
                 "for-own": {
                   "version": "0.1.4",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "for-in": "0.1.5"
+                  },
                   "dependencies": {
                     "for-in": {
                       "version": "0.1.5",
@@ -2034,16 +2827,29 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.2",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              },
               "dependencies": {
                 "glob-base": {
                   "version": "0.3.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
+                  },
                   "dependencies": {
                     "glob-parent": {
                       "version": "2.0.0",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "is-glob": "2.0.1"
+                      }
                     }
                   }
                 },
@@ -2058,11 +2864,18 @@
               "version": "0.4.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+              },
               "dependencies": {
                 "is-equal-shallow": {
                   "version": "0.1.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "is-primitive": "2.0.0"
+                  }
                 },
                 "is-primitive": {
                   "version": "2.0.0",
@@ -2077,6 +2890,9 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -2088,7 +2904,10 @@
         "pkg-up": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
         },
         "resolve-from": {
           "version": "2.0.0",
@@ -2098,7 +2917,10 @@
         "rimraf": {
           "version": "2.5.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.0.3"
+          }
         },
         "signal-exit": {
           "version": "3.0.0",
@@ -2114,6 +2936,14 @@
           "version": "1.2.3",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "foreground-child": "1.5.1",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.1",
+            "rimraf": "2.5.2",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
@@ -2129,6 +2959,9 @@
               "version": "1.2.10",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
@@ -2143,11 +2976,22 @@
           "version": "1.1.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "lodash.assign": "4.0.9",
+            "micromatch": "2.3.8",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          },
           "dependencies": {
             "lodash.assign": {
               "version": "4.0.9",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
+              },
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
@@ -2165,16 +3009,32 @@
               "version": "1.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
+                  },
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                      },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
@@ -2185,11 +3045,17 @@
                           "version": "2.2.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
@@ -2209,6 +3075,9 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
@@ -2221,6 +3090,9 @@
                           "version": "2.0.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "is-utf8": "0.2.1"
+                          },
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
@@ -2235,6 +3107,12 @@
                       "version": "2.3.5",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
@@ -2245,6 +3123,9 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
@@ -2262,11 +3143,18 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.1"
+                              },
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
@@ -2279,6 +3167,10 @@
                               "version": "1.0.2",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
+                              },
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
@@ -2300,6 +3192,11 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
@@ -2315,6 +3212,9 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
@@ -2340,6 +3240,21 @@
           "version": "4.7.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.0.9",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.1",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -2350,11 +3265,19 @@
               "version": "3.2.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "string-width": "1.0.1",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.0.0"
+              },
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -2366,7 +3289,10 @@
                 "wrap-ansi": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "string-width": "1.0.1"
+                  }
                 }
               }
             },
@@ -2379,6 +3305,10 @@
               "version": "4.0.9",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
+              },
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
@@ -2396,11 +3326,17 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "lcid": "1.0.0"
+              },
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "invert-kv": "1.0.0"
+                  },
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
@@ -2415,11 +3351,24 @@
               "version": "1.1.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.0",
+                "symbol": "0.2.3"
+              },
               "dependencies": {
                 "load-json-file": {
                   "version": "1.1.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.4",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "strip-bom": "2.0.0"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.4",
@@ -2430,11 +3379,17 @@
                       "version": "2.2.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "error-ex": "1.3.0"
+                      },
                       "dependencies": {
                         "error-ex": {
                           "version": "1.3.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "is-arrayish": "0.2.1"
+                          },
                           "dependencies": {
                             "is-arrayish": {
                               "version": "0.2.1",
@@ -2454,6 +3409,9 @@
                       "version": "2.0.1",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -2466,6 +3424,9 @@
                       "version": "2.0.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "is-utf8": "0.2.1"
+                      },
                       "dependencies": {
                         "is-utf8": {
                           "version": "0.2.1",
@@ -2492,16 +3453,32 @@
               "version": "1.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
+                  },
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                      },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
@@ -2512,11 +3489,17 @@
                           "version": "2.2.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
@@ -2536,6 +3519,9 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
@@ -2548,6 +3534,9 @@
                           "version": "2.0.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "is-utf8": "0.2.1"
+                          },
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
@@ -2562,6 +3551,12 @@
                       "version": "2.3.5",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
@@ -2572,6 +3567,9 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
@@ -2589,11 +3587,18 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.1"
+                              },
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
@@ -2606,6 +3611,10 @@
                               "version": "1.0.2",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
+                              },
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
@@ -2627,6 +3636,11 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
@@ -2642,6 +3656,9 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
@@ -2670,11 +3687,19 @@
               "version": "1.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -2687,6 +3712,9 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -2699,6 +3727,9 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -2723,6 +3754,10 @@
               "version": "2.4.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "camelcase": "2.1.1",
+                "lodash.assign": "4.0.9"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
@@ -2748,11 +3783,14 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -2772,7 +3810,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2791,9 +3837,13 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2833,13 +3883,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pkg-config": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -2851,7 +3909,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2860,9 +3923,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "1.1.8",
@@ -2893,9 +3956,15 @@
       "dev": true
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2905,32 +3974,77 @@
       }
     },
     "readable-stream": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
-      "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw=="
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -2942,29 +4056,42 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "run-parallel": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.8.tgz",
+      "integrity": "sha512-e5t1NVhr5VWmD9V9U4KjjSGkf5w6CcTPgw11A3CfIvkkQxlAKzX3usPUp1NUQTmpOOjU+f9QRICU3tMbKwn9ZQ==",
       "dev": true
     },
     "rx-lite": {
@@ -2974,9 +4101,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sax": {
       "version": "1.2.1",
@@ -2985,9 +4112,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2998,7 +4125,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -3026,19 +4156,29 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
+      }
     },
     "split": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3047,9 +4187,19 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3068,13 +4218,33 @@
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/standard/-/standard-6.0.8.tgz",
       "integrity": "sha1-sOZl4yJ32jy5nyEmmxBC2B7+sGs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint": "2.2.0",
+        "eslint-config-standard": "5.1.0",
+        "eslint-config-standard-jsx": "1.1.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-react": "4.3.0",
+        "eslint-plugin-standard": "1.3.3",
+        "standard-engine": "3.3.1",
+        "xtend": "4.0.1"
+      }
     },
     "standard-engine": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-3.3.1.tgz",
       "integrity": "sha1-sveY3k5NPh+s7UJcgTaDGmZ0CO0=",
       "dev": true,
+      "requires": {
+        "defaults": "1.0.3",
+        "deglob": "1.1.2",
+        "find-root": "1.1.0",
+        "get-stdin": "5.0.1",
+        "minimist": "1.2.0",
+        "multiline": "1.0.2",
+        "pkg-config": "1.1.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -3088,17 +4258,28 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3108,13 +4289,19 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      },
       "dependencies": {
         "get-stdin": {
           "version": "4.0.1",
@@ -3140,7 +4327,21 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.10",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3148,10 +4349,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -3160,6 +4374,27 @@
       "resolved": "https://registry.npmjs.org/tap/-/tap-5.8.0.tgz",
       "integrity": "sha1-y9cWSITLyFVm+ck3ooBrkR9Cmtw=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "clean-yaml-object": "0.1.0",
+        "codecov.io": "0.1.6",
+        "coveralls": "2.13.3",
+        "deeper": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "isexe": "1.1.2",
+        "js-yaml": "3.11.0",
+        "nyc": "6.6.1",
+        "only-shallow": "1.2.0",
+        "opener": "1.4.3",
+        "readable-stream": "2.3.6",
+        "signal-exit": "2.1.2",
+        "stack-utils": "0.4.0",
+        "supports-color": "1.3.1",
+        "tap-mocha-reporter": "0.0.27",
+        "tap-parser": "1.3.2",
+        "tmatch": "2.0.1"
+      },
       "dependencies": {
         "isexe": {
           "version": "1.1.2",
@@ -3186,6 +4421,17 @@
       "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-0.0.27.tgz",
       "integrity": "sha1-svcvPh6Lp4DuApGPzes6QNqAGPc=",
       "dev": true,
+      "requires": {
+        "color-support": "1.1.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.11.0",
+        "readable-stream": "1.1.14",
+        "tap-parser": "1.3.2",
+        "unicode-length": "1.0.3"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -3199,7 +4445,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3214,23 +4466,54 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.3.2.tgz",
       "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "events-to-array": "1.1.2",
+        "inherits": "2.0.3",
+        "js-yaml": "3.11.0",
+        "readable-stream": "2.3.6"
+      }
     },
     "tape": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
       "integrity": "sha1-Df7scJIn+8yRcKvn8EaWKycUMds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-equal": "0.1.2",
+        "defined": "0.0.0",
+        "inherits": "2.0.3",
+        "jsonify": "0.0.0",
+        "resumer": "0.0.0",
+        "split": "0.2.10",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
     },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
     },
     "tar-pack": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+      "requires": {
+        "debug": "2.6.9",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.6",
+        "rimraf": "2.6.2",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -3251,20 +4534,20 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -3276,7 +4559,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -3293,7 +4579,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
+      }
     },
     "uniq": {
       "version": "1.0.1",
@@ -3306,6 +4596,10 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -3319,13 +4613,19 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.0.tgz",
       "integrity": "sha1-8GU1cED7NcOzEdTl3DZITZbb6gY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tape": "2.3.0"
+      }
     },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3333,25 +4633,43 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -3368,19 +4686,29 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xml2js": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sax": "1.2.1",
+        "xmlbuilder": "4.2.1"
+      }
     },
     "xmlbuilder": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "host": "https://autocannon-assets.s3-eu-west-1.amazonaws.com"
   },
   "dependencies": {
-    "nan": "^2.3.0",
+    "nan": "^2.10.0",
     "node-pre-gyp": "0.6.x"
   }
 }


### PR DESCRIPTION
Some deprecated APIs were removed on the V8 shipped with Node.js 10. This PR fixes those API calls, as well as update Nan to make it work with Node.js 10.