### PR TITLE
Fix leak caused by implementation change in included hdr-histogram_c

### DIFF
--- a/hdr_histogram_wrap.cc
+++ b/hdr_histogram_wrap.cc
@@ -30,7 +30,7 @@ NAN_MODULE_INIT(HdrHistogramWrap::Init) {
 
 HdrHistogramWrap::~HdrHistogramWrap() {
   if (this->histogram) {
-    delete this->histogram;
+    hdr_close(this->histogram);
   }
 }
 


### PR DESCRIPTION
Reference:
https://github.com/ccollie/native-hdr-histogram/commit/911dcc3556ffd7352d3440b97c15a2ed914ed516#diff-63e5acd8d8cb2fcb24ec4e10338374d0L46